### PR TITLE
Handle addon releases which support multiple game versions

### DIFF
--- a/utils/curse.js
+++ b/utils/curse.js
@@ -78,7 +78,7 @@ function getLatestFile(addonId, releaseType = ADDON_RELEASE_TYPE.STABLE) {
         .then(curseAddon => {
             return _.find(curseAddon.latestFiles, file => (
                 file.releaseType === releaseType
-                    && file.gameVersionFlavor === 'wow_retail'
+                    && _.some(file.sortableGameVersion, { gameVersionTypeId: 517 })
             ));
         })
     ;

--- a/utils/fingerprint.worker.js
+++ b/utils/fingerprint.worker.js
@@ -34,6 +34,7 @@ function lengthWithoutWhitespace(buffer) {
 function getFileHash(filePath, ignoreWhitespace) {
     return readFileAsync(filePath)
         .then(content => getHash(content, undefined, ignoreWhitespace))
+        .catch(() => '')
     ;
 }
 
@@ -97,6 +98,7 @@ function getIncludes(indexFile, matchingFiles) {
     }
     matchingFiles.push(indexFile);
     return readFileAsync(indexFile, 'utf8')
+        .catch(() => '')
         .then(content => {
             let includes = null;
             if(indexFile.toLowerCase().endsWith('.toc')) {


### PR DESCRIPTION
As the title says. Was using a bad field in the addon metadata which doesn't properly show a file supporting multiple game versions (it just showed the first supported version). Updated this reference in a few places to correctly fetch the wow_retail matching versions.

There was also an error rearing its head with some addons trying to include files that weren't included in their zip (and weren't dependencies). Blindly ignoring the missing files seemed to give the correct hash, so yeah, great one :)

Closes #16